### PR TITLE
HEC-1107 Start page enhancements

### DIFF
--- a/app/uk/gov/hmrc/hecapplicantfrontend/connectors/HECConnector.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/connectors/HECConnector.scala
@@ -41,6 +41,8 @@ trait HECConnector {
 
   def getCtutr(crn: CRN)(implicit hc: HeaderCarrier): EitherT[Future, Error, HttpResponse]
 
+  def getUnexpiredTaxCheckCodes()(implicit hc: HeaderCarrier): EitherT[Future, Error, HttpResponse]
+
 }
 
 @Singleton
@@ -62,6 +64,8 @@ class HECConnectorImpl @Inject() (http: HttpClient, servicesConfig: ServicesConf
     d.format(DateTimeFormatter.ISO_LOCAL_DATE)
 
   private def getCtutrUrl(crn: CRN): String = s"$baseUrl/hec/ctutr/${crn.value}"
+
+  private val getTaxCheckCodesUrl: String = s"$baseUrl/hec/unexpired-tax-checks"
 
   override def saveTaxCheck(
     taxCheckData: HECTaxCheckData
@@ -99,4 +103,11 @@ class HECConnectorImpl @Inject() (http: HttpClient, servicesConfig: ServicesConf
         .recover { case e => Left(Error(e)) }
     )
 
+  def getUnexpiredTaxCheckCodes()(implicit hc: HeaderCarrier): EitherT[Future, Error, HttpResponse] =
+    EitherT[Future, Error, HttpResponse](
+      http
+        .GET[HttpResponse](getTaxCheckCodesUrl)
+        .map(Right(_))
+        .recover { case e => Left(Error(e)) }
+    )
 }

--- a/app/uk/gov/hmrc/hecapplicantfrontend/controllers/StartController.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/controllers/StartController.scala
@@ -178,7 +178,8 @@ class StartController @Inject() (
                       citizenDetails.name,
                       citizenDetails.dateOfBirth,
                       maybeEmail.map(EmailAddress(_)),
-                      None
+                      None,
+                      List.empty
                     )
                 )
                 .toEither
@@ -207,7 +208,8 @@ class StartController @Inject() (
           GGCredId(ggCredId.value),
           _,
           maybeEmail.map(EmailAddress(_)),
-          None
+          None,
+          List.empty
         )
       )
       .toEither

--- a/app/uk/gov/hmrc/hecapplicantfrontend/controllers/TaxChecksListController.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/controllers/TaxChecksListController.scala
@@ -38,7 +38,7 @@ class TaxChecksListController @Inject() (
   val unexpiredTaxChecks: Action[AnyContent] = authAction.andThen(sessionDataAction) { implicit request =>
     request.sessionData.retrievedUserData.unexpiredTaxChecks match {
       case Nil       =>
-        logger.warn("No tax chek codes found")
+        logger.warn("No tax check codes found")
         InternalServerError
       case taxChecks =>
         Ok(s"$taxChecks")

--- a/app/uk/gov/hmrc/hecapplicantfrontend/controllers/TaxChecksListController.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/controllers/TaxChecksListController.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hecapplicantfrontend.controllers
+
+import com.google.inject.{Inject, Singleton}
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.hecapplicantfrontend.controllers.actions.{AuthAction, SessionDataAction}
+import uk.gov.hmrc.hecapplicantfrontend.util.Logging
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+@Singleton
+class TaxChecksListController @Inject() (
+  authAction: AuthAction,
+  sessionDataAction: SessionDataAction,
+  mcc: MessagesControllerComponents
+) extends FrontendController(mcc)
+    with I18nSupport
+    with Logging {
+
+  /**
+    * Fetches unexpired tax check codes for applicant
+    */
+  val unexpiredTaxChecks: Action[AnyContent] = authAction.andThen(sessionDataAction) { implicit request =>
+    request.sessionData.retrievedUserData.unexpiredTaxChecks match {
+      case Nil       =>
+        logger.warn("No tax chek codes found")
+        InternalServerError
+      case taxChecks =>
+        Ok(s"$taxChecks")
+    }
+  }
+}

--- a/app/uk/gov/hmrc/hecapplicantfrontend/models/RetrievedApplicantData.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/models/RetrievedApplicantData.scala
@@ -21,6 +21,7 @@ import uk.gov.hmrc.hecapplicantfrontend.models.ids.{CTUTR, GGCredId, NINO, SAUTR
 
 sealed trait RetrievedApplicantData extends Product with Serializable {
   val entityType: EntityType
+  val unexpiredTaxChecks: List[TaxCheckListItem]
 }
 
 object RetrievedApplicantData {
@@ -32,7 +33,8 @@ object RetrievedApplicantData {
     name: Name,
     dateOfBirth: DateOfBirth,
     emailAddress: Option[EmailAddress],
-    saStatus: Option[SAStatusResponse]
+    saStatus: Option[SAStatusResponse],
+    unexpiredTaxChecks: List[TaxCheckListItem]
   ) extends RetrievedApplicantData {
     val entityType: EntityType = EntityType.Individual
   }
@@ -41,7 +43,8 @@ object RetrievedApplicantData {
     ggCredId: GGCredId,
     ctutr: Option[CTUTR],
     emailAddress: Option[EmailAddress],
-    companyName: Option[CompanyHouseName]
+    companyName: Option[CompanyHouseName],
+    unexpiredTaxChecks: List[TaxCheckListItem]
   ) extends RetrievedApplicantData {
     val entityType: EntityType = EntityType.Company
   }

--- a/app/uk/gov/hmrc/hecapplicantfrontend/models/TaxCheckListItem.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/models/TaxCheckListItem.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hecapplicantfrontend.models
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.hecapplicantfrontend.models.licence.LicenceType
+
+import java.time.{LocalDate, ZonedDateTime}
+
+final case class TaxCheckListItem(
+  licenceType: LicenceType,
+  taxCheckCode: HECTaxCheckCode,
+  expiresAfter: LocalDate,
+  createDate: ZonedDateTime
+)
+
+object TaxCheckListItem {
+  implicit val format: OFormat[TaxCheckListItem] = Json.format
+}

--- a/app/uk/gov/hmrc/hecapplicantfrontend/services/JourneyService.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/services/JourneyService.scala
@@ -89,11 +89,14 @@ class JourneyServiceImpl @Inject() (sessionStore: SessionStore)(implicit ex: Exe
         routes.EntityTypeController.entityType()
     )
 
-  override def firstPage(session: HECSession): Call =
+  override def firstPage(session: HECSession): Call = {
+    val hasTaxCheckCodes = session.retrievedUserData.unexpiredTaxChecks.nonEmpty
     session.retrievedUserData match {
-      case _: IndividualRetrievedData => routes.ConfirmIndividualDetailsController.confirmIndividualDetails()
-      case _: CompanyRetrievedData    => routes.LicenceDetailsController.licenceType()
+      case _: IndividualRetrievedData                  => routes.ConfirmIndividualDetailsController.confirmIndividualDetails()
+      case _: CompanyRetrievedData if hasTaxCheckCodes => routes.TaxChecksListController.unexpiredTaxChecks()
+      case _: CompanyRetrievedData                     => routes.LicenceDetailsController.licenceType()
     }
+  }
 
   override def updateAndNext(current: Call, updatedSession: HECSession)(implicit
     r: RequestWithSessionData[_],

--- a/app/uk/gov/hmrc/hecapplicantfrontend/services/JourneyService.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/services/JourneyService.scala
@@ -215,7 +215,7 @@ class JourneyServiceImpl @Inject() (sessionStore: SessionStore)(implicit ex: Exe
       case Some(taxSituation) =>
         if (saTaxSituations.contains(taxSituation)) {
           session.retrievedUserData match {
-            case IndividualRetrievedData(_, _, Some(_), _, _, _, Some(saStatus)) =>
+            case IndividualRetrievedData(_, _, Some(_), _, _, _, Some(saStatus), _) =>
               saStatus.status match {
                 case SAStatus.ReturnFound        => routes.SAController.saIncomeStatement()
                 case SAStatus.NoticeToFileIssued => routes.CheckYourAnswersController.checkYourAnswers()
@@ -238,10 +238,10 @@ class JourneyServiceImpl @Inject() (sessionStore: SessionStore)(implicit ex: Exe
 
   private def companyRegistrationNumberRoute(session: HECSession) =
     session.retrievedUserData match {
-      case _: IndividualRetrievedData             =>
+      case _: IndividualRetrievedData                =>
         sys.error("This may never happen, Individual data shouldn't be present  in company journey")
-      case CompanyRetrievedData(_, _, _, Some(_)) => routes.CompanyDetailsController.confirmCompanyDetails()
-      case _                                      => routes.CompanyDetailsNotFoundController.companyNotFound()
+      case CompanyRetrievedData(_, _, _, Some(_), _) => routes.CompanyDetailsController.confirmCompanyDetails()
+      case _                                         => routes.CompanyDetailsNotFoundController.companyNotFound()
     }
 
 }
@@ -271,7 +271,7 @@ object JourneyServiceImpl {
     retrievedUserData: RetrievedApplicantData
   ): Boolean =
     (retrievedUserData, saIncomeDeclared) match {
-      case (IndividualRetrievedData(_, _, _, _, _, _, Some(SAStatusResponse(_, _, ReturnFound))), None)
+      case (IndividualRetrievedData(_, _, _, _, _, _, Some(SAStatusResponse(_, _, ReturnFound)), _), None)
           if saTaxSituations.contains(taxSituation) =>
         false
       case _ => true

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,6 +6,8 @@ GET        /assets/*file            controllers.Assets.versioned(path = "/public
 
 GET        /start                   uk.gov.hmrc.hecapplicantfrontend.controllers.StartController.start
 
+GET        /unexpired-tax-checks    uk.gov.hmrc.hecapplicantfrontend.controllers.TaxChecksListController.unexpiredTaxChecks
+
 GET        /confirm-details         uk.gov.hmrc.hecapplicantfrontend.controllers.ConfirmIndividualDetailsController.confirmIndividualDetails
 POST       /confirm-details         uk.gov.hmrc.hecapplicantfrontend.controllers.ConfirmIndividualDetailsController.confirmIndividualDetailsSubmit
 GET        /not-right-details       uk.gov.hmrc.hecapplicantfrontend.controllers.ConfirmIndividualDetailsController.confirmIndividualDetailsExit

--- a/test/uk/gov/hmrc/hecapplicantfrontend/connectors/HECConnectorImplSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/connectors/HECConnectorImplSpec.scala
@@ -135,6 +135,19 @@ class HECConnectorImplSpec extends AnyWordSpec with Matchers with MockFactory wi
 
     }
 
+    "handling requests to get unexpired tax checks" must {
+
+      implicit val hc: HeaderCarrier = HeaderCarrier()
+
+      val expectedUrl = s"$protocol://$host:$port/hec/unexpired-tax-checks"
+
+      behave like connectorBehaviour(
+        mockGet(expectedUrl)(_),
+        () => connector.getUnexpiredTaxCheckCodes()
+      )
+
+    }
+
   }
 
 }

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/CRNControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/CRNControllerSpec.scala
@@ -61,7 +61,7 @@ class CRNControllerSpec
   )
 
   val controller           = instanceOf[CRNController]
-  val companyRetrievedData = CompanyRetrievedData(GGCredId(""), None, None, None)
+  val companyRetrievedData = CompanyRetrievedData(GGCredId(""), None, None, None, List.empty)
 
   def mockFindCompany(crn: CRN)(
     result: Either[Error, Option[CompanyHouseDetails]]

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/CheckYourAnswersControllerSpec.scala
@@ -55,9 +55,18 @@ class CheckYourAnswersControllerSpec
   val controller = instanceOf[CheckYourAnswersController]
 
   val individualRetrievedData =
-    IndividualRetrievedData(GGCredId(""), NINO(""), None, Name("", ""), DateOfBirth(LocalDate.now()), None, None)
+    IndividualRetrievedData(
+      GGCredId(""),
+      NINO(""),
+      None,
+      Name("", ""),
+      DateOfBirth(LocalDate.now()),
+      None,
+      None,
+      List.empty
+    )
 
-  val companyRetrievedData = CompanyRetrievedData(GGCredId(""), None, None, None)
+  val companyRetrievedData = CompanyRetrievedData(GGCredId(""), None, None, None, List.empty)
 
   def mockSaveTaxCheck(applicantData: RetrievedApplicantData, completeAnswers: CompleteUserAnswers)(
     result: Either[Error, HECTaxCheck]

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/ConfirmIndividualDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/ConfirmIndividualDetailsControllerSpec.scala
@@ -56,7 +56,7 @@ class ConfirmIndividualDetailsControllerSpec
       "redirect to the start endpoint" when {
 
         "company details are found in session" in {
-          val companyRetrievedData = CompanyRetrievedData(GGCredId(""), None, None, None)
+          val companyRetrievedData = CompanyRetrievedData(GGCredId(""), None, None, None, List.empty)
 
           inSequence {
             mockAuthWithNoRetrievals()
@@ -74,7 +74,7 @@ class ConfirmIndividualDetailsControllerSpec
           val dateOfBirth = DateOfBirth(LocalDate.of(2000, 12, 3))
 
           val session = HECSession(
-            IndividualRetrievedData(GGCredId(""), NINO(""), None, name, dateOfBirth, None, None),
+            IndividualRetrievedData(GGCredId(""), NINO(""), None, name, dateOfBirth, None, None, List.empty),
             UserAnswers.empty,
             None
           )
@@ -118,7 +118,7 @@ class ConfirmIndividualDetailsControllerSpec
       "redirect to the start endpoint" when {
 
         "company details are found in session" in {
-          val companyRetrievedData = CompanyRetrievedData(GGCredId(""), None, None, None)
+          val companyRetrievedData = CompanyRetrievedData(GGCredId(""), None, None, None, List.empty)
 
           inSequence {
             mockAuthWithNoRetrievals()
@@ -141,7 +141,8 @@ class ConfirmIndividualDetailsControllerSpec
               Name("", ""),
               DateOfBirth(LocalDate.now()),
               None,
-              None
+              None,
+              List.empty
             ),
             UserAnswers.empty,
             None
@@ -173,7 +174,8 @@ class ConfirmIndividualDetailsControllerSpec
               Name("", ""),
               DateOfBirth(LocalDate.now()),
               None,
-              None
+              None,
+              List.empty
             ),
             UserAnswers.empty,
             None
@@ -205,7 +207,7 @@ class ConfirmIndividualDetailsControllerSpec
       "redirect to the start endpoint" when {
 
         "company details are found in session" in {
-          val companyRetrievedData = CompanyRetrievedData(GGCredId(""), None, None, None)
+          val companyRetrievedData = CompanyRetrievedData(GGCredId(""), None, None, None, List.empty)
 
           inSequence {
             mockAuthWithNoRetrievals()
@@ -227,7 +229,8 @@ class ConfirmIndividualDetailsControllerSpec
               Name("", ""),
               DateOfBirth(LocalDate.now()),
               None,
-              None
+              None,
+              List.empty
             ),
             UserAnswers.empty,
             None

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/EntityTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/EntityTypeControllerSpec.scala
@@ -50,10 +50,19 @@ class EntityTypeControllerSpec
   val controller = instanceOf[EntityTypeController]
 
   val individuaRetrievedlData =
-    IndividualRetrievedData(GGCredId(""), NINO(""), None, Name("", ""), DateOfBirth(LocalDate.now()), None, None)
+    IndividualRetrievedData(
+      GGCredId(""),
+      NINO(""),
+      None,
+      Name("", ""),
+      DateOfBirth(LocalDate.now()),
+      None,
+      None,
+      List.empty
+    )
 
   val companyRetrievedData =
-    CompanyRetrievedData(GGCredId(""), None, None, None)
+    CompanyRetrievedData(GGCredId(""), None, None, None, List.empty)
 
   "EntityTypeController" when {
 

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/LicenceDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/LicenceDetailsControllerSpec.scala
@@ -51,10 +51,19 @@ class LicenceDetailsControllerSpec
   val controller: LicenceDetailsController = instanceOf[LicenceDetailsController]
 
   val individuaRetrievedlData: IndividualRetrievedData =
-    IndividualRetrievedData(GGCredId(""), NINO(""), None, Name("", ""), DateOfBirth(LocalDate.now()), None, None)
+    IndividualRetrievedData(
+      GGCredId(""),
+      NINO(""),
+      None,
+      Name("", ""),
+      DateOfBirth(LocalDate.now()),
+      None,
+      None,
+      List.empty
+    )
 
   val companyRetrievedData: CompanyRetrievedData =
-    CompanyRetrievedData(GGCredId(""), None, None, None)
+    CompanyRetrievedData(GGCredId(""), None, None, None, List.empty)
 
   "LicenceDetailsController" when {
 

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/SAControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/SAControllerSpec.scala
@@ -51,7 +51,16 @@ class SAControllerSpec
   private val controller = instanceOf[SAController]
 
   val individuaRetrievedlData: IndividualRetrievedData =
-    IndividualRetrievedData(GGCredId(""), NINO(""), None, Name("", ""), DateOfBirth(LocalDate.now()), None, None)
+    IndividualRetrievedData(
+      GGCredId(""),
+      NINO(""),
+      None,
+      Name("", ""),
+      DateOfBirth(LocalDate.now()),
+      None,
+      None,
+      List.empty
+    )
 
   "SAController" when {
 

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/StartControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/StartControllerSpec.scala
@@ -142,14 +142,16 @@ class StartControllerSpec extends ControllerSpec with AuthSupport with SessionSu
         Name("First", "Last"),
         DateOfBirth(LocalDate.now()),
         Some(emailAddress),
-        None
+        None,
+        List.empty
       )
 
       val completeCompanyRetrievedData = CompanyRetrievedData(
         ggCredId,
         Some(ctutr),
         Some(emailAddress),
-        None
+        None,
+        List.empty
       )
 
       def performAction(): Future[Result] = controller.start(FakeRequest())

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/TaxCheckCompleteControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/TaxCheckCompleteControllerSpec.scala
@@ -47,10 +47,19 @@ class TaxCheckCompleteControllerSpec
   val controller = instanceOf[TaxCheckCompleteController]
 
   val individualRetrievedData =
-    IndividualRetrievedData(GGCredId(""), NINO(""), None, Name("", ""), DateOfBirth(LocalDate.now()), None, None)
+    IndividualRetrievedData(
+      GGCredId(""),
+      NINO(""),
+      None,
+      Name("", ""),
+      DateOfBirth(LocalDate.now()),
+      None,
+      None,
+      List.empty
+    )
 
   val companyRetrievedData =
-    CompanyRetrievedData(GGCredId(""), None, None, None)
+    CompanyRetrievedData(GGCredId(""), None, None, None, List.empty)
 
   "TaxCheckCompleteController" when {
 

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/TaxSituationControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/TaxSituationControllerSpec.scala
@@ -73,10 +73,19 @@ class TaxSituationControllerSpec
   val controller = instanceOf[TaxSituationController]
 
   val individualRetrievedData =
-    IndividualRetrievedData(GGCredId(""), NINO(""), None, Name("", ""), DateOfBirth(LocalDate.now()), None, None)
+    IndividualRetrievedData(
+      GGCredId(""),
+      NINO(""),
+      None,
+      Name("", ""),
+      DateOfBirth(LocalDate.now()),
+      None,
+      None,
+      List.empty
+    )
 
   val companyRetrievedData =
-    CompanyRetrievedData(GGCredId(""), None, None, None)
+    CompanyRetrievedData(GGCredId(""), None, None, None, List.empty)
 
   "TaxSituationController" when {
 

--- a/test/uk/gov/hmrc/hecapplicantfrontend/models/RetrievedApplicantDataSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/models/RetrievedApplicantDataSpec.scala
@@ -40,7 +40,8 @@ class RetrievedApplicantDataSpec extends AnyWordSpec with Matchers {
           Name("first", "last"),
           DateOfBirth(dateOfBirth),
           Some(EmailAddress("email")),
-          None
+          None,
+          List.empty
         )
 
       val individualJson = Json.parse(s"""{
@@ -53,7 +54,8 @@ class RetrievedApplicantDataSpec extends AnyWordSpec with Matchers {
           |},
           |"dateOfBirth":"$dateOfBirthStr",
           |"emailAddress":"email",
-          |"type":"Individual"
+          |"type":"Individual",
+          |"unexpiredTaxChecks":[]
           |}""".stripMargin)
 
       val companyRetrievedData: RetrievedApplicantData =
@@ -61,7 +63,8 @@ class RetrievedApplicantDataSpec extends AnyWordSpec with Matchers {
           GGCredId("ggCredId"),
           Some(CTUTR("utr")),
           Some(EmailAddress("email")),
-          Some(CompanyHouseName("Test Tech Ltd"))
+          Some(CompanyHouseName("Test Tech Ltd")),
+          List.empty
         )
 
       val companyJson = Json.parse("""{
@@ -69,7 +72,8 @@ class RetrievedApplicantDataSpec extends AnyWordSpec with Matchers {
           |"ctutr":"utr",
           |"emailAddress":"email",
           |"type":"Company",
-          |"companyName":"Test Tech Ltd"
+          |"companyName":"Test Tech Ltd",
+          |"unexpiredTaxChecks":[]
           |}""".stripMargin)
 
       "serialize Individual retrieved data" in {
@@ -91,8 +95,10 @@ class RetrievedApplicantDataSpec extends AnyWordSpec with Matchers {
 
         "only mandatory fields are present" in {
           Json
-            .fromJson[RetrievedApplicantData](Json.parse("""{"ggCredId":"ggCredId", "type":"Company"}"""))
-            .get shouldBe CompanyRetrievedData(GGCredId("ggCredId"), None, None, None)
+            .fromJson[RetrievedApplicantData](
+              Json.parse("""{"ggCredId":"ggCredId", "type":"Company", "unexpiredTaxChecks":[]}""")
+            )
+            .get shouldBe CompanyRetrievedData(GGCredId("ggCredId"), None, None, None, List.empty)
         }
       }
     }

--- a/test/uk/gov/hmrc/hecapplicantfrontend/repos/SessionStoreImplSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/repos/SessionStoreImplSpec.scala
@@ -58,7 +58,7 @@ class SessionStoreImplSpec extends AnyWordSpec with Matchers with MongoSupport w
 
     val sessionData =
       HECSession(
-        CompanyRetrievedData(GGCredId("id"), Some(CTUTR("utr")), Some(EmailAddress("email")), None),
+        CompanyRetrievedData(GGCredId("id"), Some(CTUTR("utr")), Some(EmailAddress("email")), None, List.empty),
         UserAnswers.empty,
         None
       )

--- a/test/uk/gov/hmrc/hecapplicantfrontend/services/JourneyServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/services/JourneyServiceImplSpec.scala
@@ -52,11 +52,12 @@ class JourneyServiceSpec extends AnyWordSpec with Matchers with MockFactory with
       Name("", ""),
       DateOfBirth(LocalDate.now()),
       None,
-      None
+      None,
+      List.empty
     )
 
   val companyRetrievedData: CompanyRetrievedData =
-    CompanyRetrievedData(GGCredId(""), None, None, None)
+    CompanyRetrievedData(GGCredId(""), None, None, None, List.empty)
 
   "JourneyServiceImpl" when {
 
@@ -342,7 +343,8 @@ class JourneyServiceSpec extends AnyWordSpec with Matchers with MockFactory with
               Name("", ""),
               DateOfBirth(LocalDate.now()),
               None,
-              None
+              None,
+              List.empty
             )
 
           def individualWithStatus(status: SAStatus = SAStatus.NoticeToFileIssued): IndividualRetrievedData =
@@ -1273,7 +1275,8 @@ class JourneyServiceSpec extends AnyWordSpec with Matchers with MockFactory with
             Name("", ""),
             DateOfBirth(LocalDate.now()),
             None,
-            Some(SAStatusResponse(SAUTR(""), TaxYear(2020), saStatus))
+            Some(SAStatusResponse(SAUTR(""), TaxYear(2020), saStatus)),
+            List.empty
           )
           HECSession(
             individualData,

--- a/test/uk/gov/hmrc/hecapplicantfrontend/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/services/TaxCheckServiceImplSpec.scala
@@ -91,7 +91,8 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
         Name("first", "last"),
         DateOfBirth(LocalDate.now()),
         Some(email),
-        None
+        None,
+        List.empty
       )
 
       val completeAnswers = CompleteUserAnswers(

--- a/test/uk/gov/hmrc/hecapplicantfrontend/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/services/TaxCheckServiceImplSpec.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.hecapplicantfrontend.services
 
-import java.time.LocalDate
 import cats.data.EitherT
 import cats.instances.future._
 import org.scalamock.scalatest.MockFactory
@@ -30,12 +29,13 @@ import uk.gov.hmrc.hecapplicantfrontend.models.HECTaxCheckData.IndividualHECTaxC
 import uk.gov.hmrc.hecapplicantfrontend.models.RetrievedApplicantData.IndividualRetrievedData
 import uk.gov.hmrc.hecapplicantfrontend.models.TaxDetails.IndividualTaxDetails
 import uk.gov.hmrc.hecapplicantfrontend.models.UserAnswers.CompleteUserAnswers
-import uk.gov.hmrc.hecapplicantfrontend.models.ids.{CRN, CTUTR, GGCredId, NINO, SAUTR}
+import uk.gov.hmrc.hecapplicantfrontend.models.ids._
 import uk.gov.hmrc.hecapplicantfrontend.models.licence.{LicenceDetails, LicenceTimeTrading, LicenceType, LicenceValidityPeriod}
-import uk.gov.hmrc.hecapplicantfrontend.models.{AccountingPeriod, CTStatus, CTStatusResponse, DateOfBirth, EmailAddress, Error, HECTaxCheck, HECTaxCheckCode, HECTaxCheckData, IncomeDeclared, Name, SAStatus, SAStatusResponse, TaxSituation, TaxYear}
-import TaxCheckService._
+import uk.gov.hmrc.hecapplicantfrontend.models.{AccountingPeriod, CTStatus, CTStatusResponse, DateOfBirth, EmailAddress, Error, HECTaxCheck, HECTaxCheckCode, HECTaxCheckData, IncomeDeclared, Name, SAStatus, SAStatusResponse, TaxCheckListItem, TaxSituation, TaxYear}
+import uk.gov.hmrc.hecapplicantfrontend.services.TaxCheckService._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
+import java.time.{LocalDate, ZonedDateTime}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory {
@@ -66,6 +66,12 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
     (mockHECConnector
       .getCtutr(_: CRN)(_: HeaderCarrier))
       .expects(crn, *)
+      .returning(EitherT.fromEither(result))
+
+  def mockGetUnexpiredTaxChecks(result: Either[Error, HttpResponse]) =
+    (mockHECConnector
+      .getUnexpiredTaxCheckCodes()(_: HeaderCarrier))
+      .expects(*)
       .returning(EitherT.fromEither(result))
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
@@ -331,6 +337,64 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
 
           val result = service.getCtutr(crn)
           await(result.value) shouldBe Right(response.ctutr)
+        }
+
+      }
+
+    }
+
+    "handling requests to get unexpired tax checks" must {
+
+      val response = List(
+        TaxCheckListItem(
+          licenceType = LicenceType.ScrapMetalMobileCollector,
+          taxCheckCode = HECTaxCheckCode("some-code"),
+          expiresAfter = LocalDate.now(),
+          createDate = ZonedDateTime.now()
+        )
+      )
+
+      val responseJson = Json.toJson(response)
+
+      "return an error" when {
+
+        "the http call fails" in {
+          mockGetUnexpiredTaxChecks(Left(Error("")))
+
+          val result = service.getUnexpiredTaxCheckCodes()
+          await(result.value) shouldBe a[Left[_, _]]
+        }
+
+        "the http response comes back with a non-OK (200) response" in {
+          mockGetUnexpiredTaxChecks(Right(HttpResponse(ACCEPTED, responseJson, emptyHeaders)))
+
+          val result = service.getUnexpiredTaxCheckCodes()
+          await(result.value) shouldBe a[Left[_, _]]
+        }
+
+        "there is no json in the response" in {
+          mockGetUnexpiredTaxChecks(Right(HttpResponse(OK, "", emptyHeaders)))
+
+          val result = service.getUnexpiredTaxCheckCodes()
+          await(result.value) shouldBe a[Left[_, _]]
+        }
+
+        "the json in the body cannot be parsed" in {
+          mockGetUnexpiredTaxChecks(Right(HttpResponse(ACCEPTED, Json.parse("{ }"), emptyHeaders)))
+
+          val result = service.getUnexpiredTaxCheckCodes()
+          await(result.value) shouldBe a[Left[_, _]]
+        }
+
+      }
+
+      "return successfully" when {
+
+        "the http call succeeds and the body of the response can be parsed" in {
+          mockGetUnexpiredTaxChecks(Right(HttpResponse(OK, responseJson, emptyHeaders)))
+
+          val result = service.getUnexpiredTaxCheckCodes()
+          await(result.value) shouldBe Right(response)
         }
 
       }


### PR DESCRIPTION
Details in tickets [HEC-1107](https://jira.tools.tax.service.gov.uk/browse/HEC-1107) & [HEC-1113](https://jira.tools.tax.service.gov.uk/browse/HEC-1113)

- changes to call HEC api and interpret results
- add unexpiredTaxChecks to RetrievedApplicantData
- added route for tax check codes list page
- updates to StartController
