### PR TITLE
Set confirmCompanyDetails answer prior to making updateAndNext call

### DIFF
--- a/app/uk/gov/hmrc/hecapplicantfrontend/controllers/CompanyDetailsController.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/controllers/CompanyDetailsController.scala
@@ -140,7 +140,10 @@ class CompanyDetailsController @Inject() (
 
           case YesNoAnswer.No =>
             // wipe CRN answer prior to navigating to next page
-            val answersWithoutCrn = request.sessionData.userAnswers.unset(_.crn)
+            val answersWithoutCrn = request.sessionData.userAnswers
+              .unset(_.crn)
+              .unset(_.companyDetailsConfirmed)
+              .copy(companyDetailsConfirmed = Some(companyDetailsConfirmed))
             callUpdateAndNext(session.copy(userAnswers = answersWithoutCrn)).fold(
               internalServerError("Could not update session and proceed"),
               Redirect

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/CompanyDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/CompanyDetailsControllerSpec.scala
@@ -356,8 +356,7 @@ class CompanyDetailsControllerSpec
           "the call to update and next fails" in {
             val answers     = UserAnswers.empty.copy(crn = Some(CRN("crn")))
             // session contains CTUTR from enrolments
-            val companyData =
-              companyLoginData.copy(ctutr = Some(CTUTR("ctutr")))
+            val companyData = companyLoginData.copy(ctutr = Some(CTUTR("ctutr")))
             val session     =
               CompanyHECSession(companyData, retrievedJourneyDataWithCompanyName, answers, None, None, List.empty)
 
@@ -399,7 +398,7 @@ class CompanyDetailsControllerSpec
               CompanyHECSession(companyLoginData, retrievedJourneyDataWithCompanyName, answers, None, None, List.empty)
 
             // should wipe out CRN answer if user says that the company name is incorrect
-            val updatedAnswers = answers.copy(crn = None)
+            val updatedAnswers = answers.copy(crn = None, companyDetailsConfirmed = Some(YesNoAnswer.No))
             val updatedSession = session.copy(userAnswers = updatedAnswers)
 
             inSequence {
@@ -491,7 +490,7 @@ class CompanyDetailsControllerSpec
             CompanyHECSession(companyLoginData, retrievedJourneyDataWithCompanyName, answers, None, None, List.empty)
 
           // should wipe out CRN answer if user says that the company name is incorrect
-          val updatedAnswers = answers.copy(crn = None)
+          val updatedAnswers = answers.copy(crn = None, companyDetailsConfirmed = Some(YesNoAnswer.No))
           val updatedSession = session.copy(userAnswers = updatedAnswers)
 
           inSequence {


### PR DESCRIPTION
@LokeshSrinivasa found during testing that the page scenario 3 of [HEC -1046](https://jira.tools.tax.service.gov.uk/browse/HEC-1046) was broken.

This was due to a bug where the answer was not being updated in the answers prior to making the `JourneyService.updateAndNext` call when the user answers with a `No` to the question of `Confirm your company details`. Since the answer was not being saved/set in the user answers, in the journey service, the missing answer would match `case None                  => sys.error("Confirm company details answer was not found")` (line 289) instead of the previous line `case Some(YesNoAnswer.No)  => routes.CRNController.companyRegistrationNumber()`