### PR TITLE
Pass error msg args to FormUtils.radioFormFormatter

### DIFF
--- a/app/uk/gov/hmrc/hecapplicantfrontend/util/FormUtils.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/util/FormUtils.scala
@@ -28,7 +28,8 @@ import scala.util.Try
 object FormUtils {
 
   def radioFormFormatter[A : Eq](
-    orderedOptions: List[A]
+    orderedOptions: List[A],
+    errorMsgArgs: List[String] = Nil
   ): Formatter[A] =
     new Formatter[A] {
       val optionsZippedWithIndex: List[(A, Int)] = orderedOptions.zipWithIndex
@@ -37,13 +38,13 @@ object FormUtils {
         key: String,
         data: Map[String, String]
       ): Either[Seq[FormError], A] = {
-        lazy val invalidError = FormError(key, "error.invalid")
+        lazy val invalidError = FormError(key, "error.invalid", errorMsgArgs)
         data
           .get(key)
           .map(_.trim())
           .filter(_.nonEmpty)
           .fold[Either[Seq[FormError], A]](
-            Left(Seq(FormError(key, "error.required")))
+            Left(Seq(FormError(key, "error.required", errorMsgArgs)))
           ) { stringValue =>
             Either
               .fromTry(Try(stringValue.toInt))

--- a/app/uk/gov/hmrc/hecapplicantfrontend/views/ChargeableForCT.scala.html
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/views/ChargeableForCT.scala.html
@@ -40,7 +40,7 @@
   @if(form.errors.nonEmpty) {
     @govukErrorSummary(ErrorSummary(errorList = form.errors.map(e => ErrorLink(
       href = Some(s"#${e.key}"),
-      content = Text(s"${messages(s"${e.key}.${e.message}")}")
+      content = Text(messages(s"${e.key}.${e.message}", e.args: _*))
     )), title = Text(messages("generic.errorSummary"))))
   }
   <h1 class="govuk-heading-xl">@title</h1>
@@ -57,7 +57,7 @@
       name = key,
       items = radioOptions,
       errorMessage = form.error(key).map(e => ErrorMessage(
-        content = Text(messages(s"$key.${e.message}"))
+        content = Text(messages(s"$key.${e.message}", e.args: _*))
       ))
     ))
     <p class="govuk-body">

--- a/conf/messages
+++ b/conf/messages
@@ -264,8 +264,8 @@ noAccountingPeriodFound.title = Your Corporation Tax accounting period
 chargeableForCT.title = Was your company chargeable for Corporation Tax for the accounting period ending {0}?
 chargeableForCT.yes = Yes
 chargeableForCT.no = No
-chargeableForCT.error.required = Select yes if your company was chargeable for corporation tax for the accounting period ending {1}
-chargeableForCT.error.invalid = Select yes if your company was chargeable for corporation tax for the accounting period ending {1}
+chargeableForCT.error.required = Select yes if your company was chargeable for corporation tax for the accounting period ending {0}
+chargeableForCT.error.invalid = Select yes if your company was chargeable for corporation tax for the accounting period ending {0}
 chargeableForCT.link = Find out about accounting periods for Corporation Tax
 
 # CT Income Declared

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/CompanyDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/CompanyDetailsControllerSpec.scala
@@ -650,7 +650,7 @@ class CompanyDetailsControllerSpec
           checkFormErrorIsDisplayed(
             performAction(formAnswer: _*),
             messageFromMessageKey("chargeableForCT.title", "5 October 2020"),
-            messageFromMessageKey("chargeableForCT.error.required")
+            messageFromMessageKey("chargeableForCT.error.required", "5 October 2020")
           )
         }
 


### PR DESCRIPTION
[Bug](https://jira.tools.tax.service.gov.uk/browse/HEC-1047?focusedCommentId=1459159&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1459159) in the chargeable-for-ct page meant that the accounting period end date was not displaying correctly. This was because the date was not being passed in the `FormError`.