### PR TITLE
Enforce max tax checks limit

### DIFF
--- a/app/uk/gov/hmrc/hecapplicantfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/config/AppConfig.scala
@@ -122,4 +122,6 @@ class AppConfig @Inject() (config: Configuration, contactFrontendConfig: Contact
   val firstPageBackUrl: String = config.get[String]("first-page-back-url")
 
   val maxCtutrAnswerAttempts: Int = config.get[Int]("ctutr-attempts.maximum-attempts")
+
+  val maxTaxChecksAllowed: Int = config.get[Int]("max-tax-checks-allowed")
 }

--- a/app/uk/gov/hmrc/hecapplicantfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/config/AppConfig.scala
@@ -123,5 +123,5 @@ class AppConfig @Inject() (config: Configuration, contactFrontendConfig: Contact
 
   val maxCtutrAnswerAttempts: Int = config.get[Int]("ctutr-attempts.maximum-attempts")
 
-  val maxTaxChecksAllowed: Int = config.get[Int]("max-tax-checks-allowed")
+  val maxTaxChecksPerLicenceType: Int = config.get[Int]("max-tax-checks-per-licence-type")
 }

--- a/app/uk/gov/hmrc/hecapplicantfrontend/controllers/LicenceDetailsController.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/controllers/LicenceDetailsController.scala
@@ -53,7 +53,8 @@ class LicenceDetailsController @Inject() (
   licenceTypePage: html.LicenceType,
   licenceTypeExitPage: html.LicenceTypeExit,
   licenceTimeTradingPage: html.LicenceTimeTrading,
-  licenceValidityPeriodPage: html.LicenceValidityPeriod
+  licenceValidityPeriodPage: html.LicenceValidityPeriod,
+  maxTaxChecksLimitExceededPage: html.MaxTaxChecksLimitExceeded
 )(implicit appConfig: AppConfig, ec: ExecutionContext)
     extends FrontendController(mcc)
     with I18nSupport
@@ -72,6 +73,11 @@ class LicenceDetailsController @Inject() (
       licenceType.fold(emptyForm)(emptyForm.fill)
     }
     Ok(licenceTypePage(form, back, licenceOptions))
+  }
+
+  val maxTaxChecksExceeded: Action[AnyContent] = authAction.andThen(sessionDataAction) { implicit request =>
+    val back = journeyService.previous(routes.LicenceDetailsController.maxTaxChecksExceeded())
+    Ok(maxTaxChecksLimitExceededPage(back))
   }
 
   val licenceTypeSubmit: Action[AnyContent] = authAction.andThen(sessionDataAction).async { implicit request =>

--- a/app/uk/gov/hmrc/hecapplicantfrontend/services/JourneyService.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/services/JourneyService.scala
@@ -262,7 +262,7 @@ class JourneyServiceImpl @Inject() (sessionStore: SessionStore)(implicit ex: Exe
           .mapValues(_.length)
           .getOrElse(licenceType, 0)
 
-        if (taxCheckCountForLicenceType > appConfig.maxTaxChecksAllowed) {
+        if (taxCheckCountForLicenceType > appConfig.maxTaxChecksPerLicenceType) {
           routes.LicenceDetailsController.maxTaxChecksExceeded()
         } else {
           routes.LicenceDetailsController.licenceTimeTrading()

--- a/app/uk/gov/hmrc/hecapplicantfrontend/services/JourneyService.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/services/JourneyService.scala
@@ -24,6 +24,7 @@ import cats.syntax.eq._
 import cats.syntax.option._
 import com.google.inject.{ImplementedBy, Inject, Singleton}
 import play.api.mvc.Call
+import uk.gov.hmrc.hecapplicantfrontend.config.AppConfig
 import uk.gov.hmrc.hecapplicantfrontend.controllers.TaxSituationController.saTaxSituations
 import uk.gov.hmrc.hecapplicantfrontend.controllers.actions.RequestWithSessionData
 import uk.gov.hmrc.hecapplicantfrontend.controllers.routes
@@ -58,7 +59,8 @@ trait JourneyService {
 }
 
 @Singleton
-class JourneyServiceImpl @Inject() (sessionStore: SessionStore)(implicit ex: ExecutionContext) extends JourneyService {
+class JourneyServiceImpl @Inject() (sessionStore: SessionStore)(implicit ex: ExecutionContext, appConfig: AppConfig)
+    extends JourneyService {
 
   implicit val callEq: Eq[Call] = Eq.instance(_.url === _.url)
 
@@ -69,7 +71,7 @@ class JourneyServiceImpl @Inject() (sessionStore: SessionStore)(implicit ex: Exe
     routes.StartController.start()                                       -> firstPage,
     routes.ConfirmIndividualDetailsController.confirmIndividualDetails() -> confirmIndividualDetailsRoute,
     routes.TaxChecksListController.unexpiredTaxChecks()                  -> (_ => routes.LicenceDetailsController.licenceType()),
-    routes.LicenceDetailsController.licenceType()                        -> (_ => routes.LicenceDetailsController.licenceTimeTrading()),
+    routes.LicenceDetailsController.licenceType()                        -> licenceTypeRoute,
     routes.LicenceDetailsController.licenceTimeTrading                   -> (_ => routes.LicenceDetailsController.recentLicenceLength()),
     routes.LicenceDetailsController.recentLicenceLength()                -> licenceValidityPeriodRoute,
     routes.EntityTypeController.entityType()                             -> entityTypeRoute,
@@ -246,6 +248,28 @@ class JourneyServiceImpl @Inject() (sessionStore: SessionStore)(implicit ex: Exe
     } else {
       routes.LicenceDetailsController.licenceType()
     }
+
+  private def licenceTypeRoute(session: HECSession): Call = {
+    val licenceTypeOpt = session.userAnswers.fold(
+      _.fold(_.licenceType, _.licenceType.some),
+      _.fold(_.licenceType, _.licenceType.some)
+    )
+
+    licenceTypeOpt match {
+      case Some(licenceType) =>
+        val taxCheckCountForLicenceType = session.unexpiredTaxChecks
+          .groupBy(_.licenceType)
+          .mapValues(_.length)
+          .getOrElse(licenceType, 0)
+
+        if (taxCheckCountForLicenceType > appConfig.maxTaxChecksAllowed) {
+          routes.LicenceDetailsController.maxTaxChecksExceeded()
+        } else {
+          routes.LicenceDetailsController.licenceTimeTrading()
+        }
+      case None              => sys.error("Could not find licence type")
+    }
+  }
 
   private def licenceValidityPeriodRoute(session: HECSession): Call =
     session.userAnswers.fold(

--- a/app/uk/gov/hmrc/hecapplicantfrontend/views/MaxTaxChecksLimitExceeded.scala.html
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/views/MaxTaxChecksLimitExceeded.scala.html
@@ -1,0 +1,31 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.i18n.Messages
+@import play.api.mvc.{Call, Request}
+@import play.twirl.api.Html
+@import uk.gov.hmrc.hecapplicantfrontend.config.AppConfig
+
+@this(layout: Layout)
+
+@(back: Call)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@key = @{"maxTaxChecksLimitExceeded"}
+@title = @{messages(s"$key.title")}
+
+@layout(pageTitle = Some(title), backLocation = Some(back)) {
+    <h1 class="govuk-heading-xl">@title</h1>
+    <p class="govuk-body govuk-!-margin-bottom-9">@Html(messages(s"$key.p1", appConfig.contactHmrcSa))</p>
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -13,6 +13,7 @@ POST       /confirm-details         uk.gov.hmrc.hecapplicantfrontend.controllers
 GET        /not-right-details       uk.gov.hmrc.hecapplicantfrontend.controllers.ConfirmIndividualDetailsController.confirmIndividualDetailsExit
 
 GET        /licence-type            uk.gov.hmrc.hecapplicantfrontend.controllers.LicenceDetailsController.licenceType
+GET        /max-tax-checks-exceeded uk.gov.hmrc.hecapplicantfrontend.controllers.LicenceDetailsController.maxTaxChecksExceeded
 POST       /licence-type            uk.gov.hmrc.hecapplicantfrontend.controllers.LicenceDetailsController.licenceTypeSubmit
 
 GET        /wrong-licence-type      uk.gov.hmrc.hecapplicantfrontend.controllers.LicenceDetailsController.licenceTypeExit

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -208,5 +208,4 @@ email-allow-list {
 
 auth-login-stub.base-url = "http://localhost:9949"
 
-# TODO verify if one number can be used for all licence types
-max-tax-checks-allowed = 20
+max-tax-checks-per-licence-type = 20

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -208,4 +208,5 @@ email-allow-list {
 
 auth-login-stub.base-url = "http://localhost:9949"
 
-
+# TODO verify if one number can be used for all licence types
+max-tax-checks-allowed = 20

--- a/conf/messages
+++ b/conf/messages
@@ -313,3 +313,7 @@ tooManyCtutrAttempts.p2=You will be unable to do a tax check for this company un
 tooManyCtutrAttempts.p3=You can go back and <a href="{0}" class="govuk-link">enter a different Company Registration Number</a>, or <a href="{1}" class="govuk-link">do a new tax check</a>.
 tooManyCtutrAttempts.companyName=Company name
 tooManyCtutrAttempts.crn=Company Registration Number
+
+# Max tax checks limit exceeded
+maxTaxChecksLimitExceeded.title = Maximum number of tax checks allowed for chosen licence type has been exceeded
+maxTaxChecksLimitExceeded.p1 = Maximum number of tax checks allowed for chosen licence type has been exceeded.

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/LicenceDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/LicenceDetailsControllerSpec.scala
@@ -305,7 +305,7 @@ class LicenceDetailsControllerSpec
 
       "redirect to the next page" when {
 
-        def nextpageRedirectTest(
+        def nextPageRedirectTest(
           session: HECSession,
           updatedSession: HECSession,
           radioIndex: String,
@@ -339,7 +339,7 @@ class LicenceDetailsControllerSpec
                 taxCheckStartDateTime = Some(now)
               )
             val updatedSession = session.copy(userAnswers = updatedAnswers)
-            nextpageRedirectTest(session, updatedSession, "1", None)
+            nextPageRedirectTest(session, updatedSession, "1", None)
           }
 
           "the user has previously completed answering questions" in {
@@ -360,7 +360,7 @@ class LicenceDetailsControllerSpec
                 answers
               )
             val updatedSession = session.copy(userAnswers = updatedAnswers, taxCheckStartDateTime = Some(now))
-            nextpageRedirectTest(session, updatedSession, "2", Some(() => mockTimeProviderNow(now)))
+            nextPageRedirectTest(session, updatedSession, "2", Some(() => mockTimeProviderNow(now)))
           }
 
           "a tax check start date time is already in session" in {
@@ -381,7 +381,7 @@ class LicenceDetailsControllerSpec
               taxCheckStartDateTime = Some(now)
             )
             val updatedSession = session.copy(userAnswers = updatedAnswers, taxCheckStartDateTime = Some(now))
-            nextpageRedirectTest(session, updatedSession, "2", None)
+            nextPageRedirectTest(session, updatedSession, "2", None)
           }
 
           "the user has not changed the licence type they have already submitted previously" in {
@@ -401,7 +401,7 @@ class LicenceDetailsControllerSpec
                 taxCheckStartDateTime = Some(now)
               )
 
-            nextpageRedirectTest(session, session, "0", None)
+            nextPageRedirectTest(session, session, "0", None)
 
           }
 
@@ -421,7 +421,7 @@ class LicenceDetailsControllerSpec
               )
             val updatedSession = session.copy(userAnswers = updatedAnswers, taxCheckStartDateTime = Some(now))
 
-            nextpageRedirectTest(session, updatedSession, "0", Some(() => mockTimeProviderNow(now)))
+            nextPageRedirectTest(session, updatedSession, "0", Some(() => mockTimeProviderNow(now)))
           }
 
           "the user has previously completed answering questions" in {
@@ -436,7 +436,7 @@ class LicenceDetailsControllerSpec
               Fixtures.companyHECSession(companyLoginData, CompanyRetrievedJourneyData.empty, answers)
             val updatedSession = session.copy(userAnswers = updatedAnswers, taxCheckStartDateTime = Some(now))
 
-            nextpageRedirectTest(session, updatedSession, "1", Some(() => mockTimeProviderNow(now)))
+            nextPageRedirectTest(session, updatedSession, "1", Some(() => mockTimeProviderNow(now)))
           }
 
           "a tax check start date time is already in session" in {
@@ -458,7 +458,7 @@ class LicenceDetailsControllerSpec
               )
             val updatedSession = session.copy(userAnswers = updatedAnswers, taxCheckStartDateTime = Some(now))
 
-            nextpageRedirectTest(session, updatedSession, "1", None)
+            nextPageRedirectTest(session, updatedSession, "1", None)
           }
 
           "the user has not changed the licence type they have already submitted previously" in {
@@ -476,7 +476,7 @@ class LicenceDetailsControllerSpec
                 Some(now),
                 List.empty
               )
-            nextpageRedirectTest(session, session, "0", None)
+            nextPageRedirectTest(session, session, "0", None)
 
           }
 

--- a/test/uk/gov/hmrc/hecapplicantfrontend/services/JourneyServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/services/JourneyServiceImplSpec.scala
@@ -43,9 +43,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class JourneyServiceImplSpec extends ControllerSpec with SessionSupport {
 
-  val maxTaxChecksAllowed                           = 3
+  val maxTaxChecksPerLicenceType                    = 3
   override lazy val additionalConfig: Configuration = Configuration(
-    ConfigFactory.parseString(s"max-tax-checks-allowed = $maxTaxChecksAllowed")
+    ConfigFactory.parseString(s"max-tax-checks-per-licence-type = $maxTaxChecksPerLicenceType")
   )
   implicit val appConf: AppConfig                   = appConfig
 

--- a/test/uk/gov/hmrc/hecapplicantfrontend/utils/Fixtures.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/utils/Fixtures.scala
@@ -206,4 +206,16 @@ object Fixtures {
     endDate = endDate,
     ctStatus = ctStatus
   )
+
+  def taxCheckListItem(
+    licenceType: LicenceType = LicenceType.DriverOfTaxisAndPrivateHires,
+    taxCheckCode: HECTaxCheckCode = HECTaxCheckCode("code"),
+    expiresAfter: LocalDate = LocalDate.now,
+    createDate: ZonedDateTime = ZonedDateTime.now
+  ): TaxCheckListItem = TaxCheckListItem(
+    licenceType = licenceType,
+    taxCheckCode = taxCheckCode,
+    expiresAfter = expiresAfter,
+    createDate = createDate
+  )
 }


### PR DESCRIPTION
When someone submits an answer on the licence type question in the applicant journey we'd do something like:
- work out how many tax check codes the user (identified by their gg cred id) has for the licence type they've just submitted
- if the number is more than a configured maximum then redirect to some exit page saying they've done too many tax checks for that licence type - it's a dummy page for now