### PR TITLE
Access denied page

### DIFF
--- a/app/uk/gov/hmrc/hecapplicantfrontend/controllers/AccessDeniedController.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/controllers/AccessDeniedController.scala
@@ -22,15 +22,17 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.hecapplicantfrontend.controllers.actions.AuthAction
 import uk.gov.hmrc.hecapplicantfrontend.util.Logging
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import uk.gov.hmrc.hecapplicantfrontend.views.html
 
 @Singleton
 class AccessDeniedController @Inject() (
   authAction: AuthAction,
-  mcc: MessagesControllerComponents
+  mcc: MessagesControllerComponents,
+  accessDeniedPage: html.AccessDenied
 ) extends FrontendController(mcc)
     with I18nSupport
     with Logging {
-  val accessDenied: Action[AnyContent] = authAction { _ =>
-    Ok("access denied")
+  val accessDenied: Action[AnyContent] = authAction { implicit request =>
+    Ok(accessDeniedPage())
   }
 }

--- a/app/uk/gov/hmrc/hecapplicantfrontend/filters/EmailAllowedListFilter.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/filters/EmailAllowedListFilter.scala
@@ -44,9 +44,9 @@ class EmailAllowedListFilter @Inject() (
   val userEmailAllowedList: List[String] = config.underlying.get[List[String]]("email-allow-list.list").value
 
   private def isExcludedEndpoint(rh: RequestHeader): Boolean =
-    rh.uri.contains(routes.AccessDeniedController.accessDenied().url) ||
-      rh.uri.contains("hmrc-frontend") ||
-      rh.uri.contains("assets")
+    rh.path.contains(routes.AccessDeniedController.accessDenied().url) ||
+      rh.path.contains("hmrc-frontend") ||
+      rh.path.contains("assets")
 
   override def apply(f: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] =
     if (userEmailListEnabled) {

--- a/app/uk/gov/hmrc/hecapplicantfrontend/filters/EmailAllowedListFilter.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/filters/EmailAllowedListFilter.scala
@@ -44,7 +44,9 @@ class EmailAllowedListFilter @Inject() (
   val userEmailAllowedList: List[String] = config.underlying.get[List[String]]("email-allow-list.list").value
 
   private def isExcludedEndpoint(rh: RequestHeader): Boolean =
-    rh.uri.contains(routes.AccessDeniedController.accessDenied().url)
+    rh.uri.contains(routes.AccessDeniedController.accessDenied().url) ||
+      rh.uri.contains("hmrc-frontend") ||
+      rh.uri.contains("assets")
 
   override def apply(f: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] =
     if (userEmailListEnabled) {

--- a/app/uk/gov/hmrc/hecapplicantfrontend/views/AccessDenied.scala.html
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/views/AccessDenied.scala.html
@@ -1,0 +1,33 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.i18n.Messages
+@import play.api.mvc.Request
+@import play.twirl.api.Html
+
+@this(layout: Layout)
+
+@()(implicit request: Request[_], messages: Messages)
+@key = @{"accessDenied"}
+@title = @{messages(s"$key.title")}
+
+@layout(pageTitle = Some(title)) {
+    <h1 class="govuk-heading-xl">@title</h1>
+    <p class="govuk-body">@Html(messages(s"$key.p1"))</p>
+    <p class="govuk-body">@Html(messages(s"$key.p2"))</p>
+    <p class="govuk-body">@Html(messages(s"$key.p3"))</p>
+    <p class="govuk-body">@Html(messages(s"$key.p4"))</p>
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -67,7 +67,7 @@ GET        /dont-have-ctutr                uk.gov.hmrc.hecapplicantfrontend.cont
 GET        /too-many-ctutr-attempts        uk.gov.hmrc.hecapplicantfrontend.controllers.CompanyDetailsController.tooManyCtutrAttempts
 GET        /cannot-do-tax-check            uk.gov.hmrc.hecapplicantfrontend.controllers.CompanyDetailsController.cannotDoTaxCheck
 
-GET        /access-denied                  uk.gov.hmrc.hecapplicantfrontend.controllers.AccessDeniedController.accessDenied
+GET        /denied-access                  uk.gov.hmrc.hecapplicantfrontend.controllers.AccessDeniedController.accessDenied
 
 # IV
 GET  /failed-iv/callback                         uk.gov.hmrc.hecapplicantfrontend.controllers.IvFailureController.ivFailure(journeyId: java.util.UUID)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -202,7 +202,7 @@ ctutr-attempts {
 }
 
 email-allow-list {
-  enabled = false
+  enabled = true
   list = [ "user@test.com" ]
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -202,7 +202,7 @@ ctutr-attempts {
 }
 
 email-allow-list {
-  enabled = true
+  enabled = false
   list = [ "user@test.com" ]
 }
 

--- a/conf/messages
+++ b/conf/messages
@@ -317,3 +317,11 @@ tooManyCtutrAttempts.crn=Company Registration Number
 # Max tax checks limit exceeded
 maxTaxChecksLimitExceeded.title = Maximum number of tax checks allowed for chosen licence type has been exceeded
 maxTaxChecksLimitExceeded.p1 = Maximum number of tax checks allowed for chosen licence type has been exceeded.
+
+# Access Denied
+accessDenied.title = You cannot access this page
+accessDenied.p1 = If you have been sent this link and cannot access it, you may be logged in with the wrong Government Gateway account.
+accessDenied.p2 = If you need any assistance accessing this link, please email:
+accessDenied.p3 = <a href="mailto:zaynah.hawa@digital.hmrc.gov.uk?subject=Private Beta link assistance">zaynah.hawa@digital.hmrc.gov.uk</a>
+accessDenied.p4 = <a href="mailto:alex.porter@digital.hmrc.gov.uk?subject=Private Beta link assistance">alex.porter@digital.hmrc.gov.uk</a>
+

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/AccessDeniedControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/AccessDeniedControllerSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hecapplicantfrontend.controllers
+
+import play.api.inject.bind
+import play.api.test.FakeRequest
+import uk.gov.hmrc.auth.core.AuthConnector
+
+class AccessDeniedControllerSpec
+    extends ControllerSpec
+    with AuthSupport
+    with SessionSupport
+    with AuthAndSessionDataBehaviour {
+
+  override def overrideBindings = List(
+    bind[AuthConnector].toInstance(mockAuthConnector)
+  )
+
+  private val controller = instanceOf[AccessDeniedController]
+
+  "AccessDeniedController" when {
+
+    "handling requests to the 'denied access' page" must {
+
+      "display the page" in {
+        mockAuthWithNoRetrievals()
+
+        checkPageIsDisplayed(
+          controller.accessDenied(FakeRequest()),
+          messageFromMessageKey("accessDenied.title")
+        )
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
Details in ticket -> [HEC-1576](https://jira.tools.tax.service.gov.uk/browse/HEC-1576)

I found that the page renders correctly when accessed directly via the endpoint, but when it gets redirected via the `EmailAllowedListFilter` due to user not being in allow list, the style does nor render correctly, it looks something like this -

<img width="1641" alt="Screenshot 2021-12-09 at 11 07 26" src="https://user-images.githubusercontent.com/13031285/145401944-83bbb649-466c-4e6b-bde8-3937bf8e6598.png">

and I see these error in the console - <img width="858" alt="Screenshot 2021-12-09 at 11 10 37" src="https://user-images.githubusercontent.com/13031285/145402050-bf3561cd-db72-4c7b-b2cc-09f83a6aa2a6.png">

@nubz's thoughts
> I think the email allow list filter is being applied to all requests except just this page/document (which then goes on to make multiple requests but each of those requests is being redirected to this page
> so when I look at the header for a stylesheet request it is being redirected to /tax-check-for-licence/denied-access in the response
> which returns text/html hence the console errors

Any ideas about why this might be so are welcome.