### PR TITLE
expired email passcode confirmation code

### DIFF
--- a/app/uk/gov/hmrc/hecapplicantfrontend/views/VerificationPasscodeExpired.scala.html
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/views/VerificationPasscodeExpired.scala.html
@@ -1,0 +1,35 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.i18n.Messages
+@import play.api.mvc.{Call, Request}
+@import play.twirl.api.Html
+@import uk.gov.hmrc.hecapplicantfrontend.controllers.routes
+
+@this(layout: Layout)
+
+@(back: Call)(implicit request:
+Request[_], messages: Messages)
+@key = @{"verifyPasscodeExpired"}
+@title = @{messages(s"$key.title")}
+
+
+@layout(pageTitle = Some(title), backLocation = Some(back)) {
+    <h1 class ="govuk-heading-xl">@title</h1>
+    <p class="govuk-body">@messages(s"$key.p1")</p>
+    <p class="govuk-body">@Html(messages(s"$key.p2", routes.ResendEmailConfirmationController.resendEmail().url, routes.StartController.start()))</p>
+
+}

--- a/conf/messages
+++ b/conf/messages
@@ -384,4 +384,8 @@ enterEmailAddress.error.tooManyChar = Email address has too many characters, it 
 resendEmailConfirmation.title = Resend email confirmation code
 resendEmailConfirmation.p1 = Send a new email confirmation code to <b>{0}</b>
 
+#verifyPasscodeExpired
+verifyPasscodeExpired.title = Email confirmation code expired
+verifyPasscodeExpired.p1 = The email confirmation code entered has expired
+verifyPasscodeExpired.p2 = You need to <a href="{0}" class="govuk-link">request a new email confirmation code</a> to confirm your email address, or you can <a href="{1}" class="govuk-link">see all your tax check codes</a>
 

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/ResendEmailConfirmationControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/ResendEmailConfirmationControllerSpec.scala
@@ -78,30 +78,11 @@ class ResendEmailConfirmationControllerSpec
           assertThrows[RuntimeException](await(performAction()))
         }
 
-        "error in updating the session " in {
-          val session        = Fixtures.individualHECSession(
-            userAnswers = Fixtures.completeIndividualUserAnswers(),
-            isEmailRequested = true,
-            userEmailAnswers = Fixtures
-              .userEmailAnswers(
-                passcodeRequestResult = PasscodeRequestResult.PasscodeSent.some
-              )
-              .some,
-            hasResentEmailConfirmation = true
-          )
-          val updatedSession = session.copy(hasResentEmailConfirmation = false)
-          inSequence {
-            mockAuthWithNoRetrievals()
-            mockGetSession(session)
-            mockStoreSession(updatedSession)(Left(Error("")))
-          }
-          assertThrows[RuntimeException](await(performAction()))
-        }
       }
 
       "display the page" in {
 
-        val session        = Fixtures.individualHECSession(
+        val session = Fixtures.individualHECSession(
           userAnswers = Fixtures.completeIndividualUserAnswers(),
           isEmailRequested = true,
           userEmailAnswers = Fixtures
@@ -111,12 +92,10 @@ class ResendEmailConfirmationControllerSpec
             .some,
           hasResentEmailConfirmation = true
         )
-        val updatedSession = session.copy(hasResentEmailConfirmation = false)
 
         inSequence {
           mockAuthWithNoRetrievals()
           mockGetSession(session)
-          mockStoreSession(updatedSession)(Right(()))
           mockJourneyServiceGetPrevious(routes.ResendEmailConfirmationController.resendEmail(), session)(
             mockPreviousCall
           )

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/VerificationPasscodeExpiredControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/VerificationPasscodeExpiredControllerSpec.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hecapplicantfrontend.controllers
+
+import cats.implicits.catsSyntaxOptionId
+import play.api.inject.bind
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.hecapplicantfrontend.models.EmailAddress
+import uk.gov.hmrc.hecapplicantfrontend.models.emailVerification.{Passcode, PasscodeRequestResult, PasscodeVerificationResult}
+import uk.gov.hmrc.hecapplicantfrontend.repos.SessionStore
+import uk.gov.hmrc.hecapplicantfrontend.services.JourneyService
+import uk.gov.hmrc.hecapplicantfrontend.utils.Fixtures
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.concurrent.Future
+
+class VerificationPasscodeExpiredControllerSpec
+    extends ControllerSpec
+    with AuthSupport
+    with SessionSupport
+    with AuthAndSessionDataBehaviour
+    with JourneyServiceSupport {
+
+  override def overrideBindings = List(
+    bind[AuthConnector].toInstance(mockAuthConnector),
+    bind[SessionStore].toInstance(mockSessionStore),
+    bind[JourneyService].toInstance(mockJourneyService)
+  )
+
+  val controller = instanceOf[VerificationPasscodeExpiredController]
+
+  "VerificationPasscodeExpiredControllerSec" when {
+
+    "handling request to verification passcode expired page" must {
+      val ggEmailId       = EmailAddress("user@test.com")
+      val expiredPasscode = Passcode("FFFFFF")
+
+      def performAction(): Future[Result] = controller.verificationPasscodeExpired(FakeRequest())
+
+      "return a technical error" when {
+
+        "passcode verification result is other than Expired" in {
+
+          List(
+            PasscodeVerificationResult.Match.some,
+            PasscodeVerificationResult.NoMatch.some,
+            PasscodeVerificationResult.TooManyAttempts.some
+          ).foreach { passcodeVerificationResult =>
+            withClue(s" For passcode  verification result :: $passcodeVerificationResult") {
+
+              val session = Fixtures.individualHECSession(
+                loginData = Fixtures.individualLoginData(emailAddress = ggEmailId.some),
+                userAnswers = Fixtures.completeIndividualUserAnswers(),
+                isEmailRequested = true,
+                userEmailAnswers = Fixtures
+                  .userEmailAnswers(
+                    passcodeRequestResult = PasscodeRequestResult.PasscodeSent.some,
+                    passcode = expiredPasscode.some,
+                    passcodeVerificationResult = passcodeVerificationResult
+                  )
+                  .some
+              )
+
+              inSequence {
+                mockAuthWithNoRetrievals()
+                mockGetSession(session)
+              }
+              assertThrows[RuntimeException](await(performAction()))
+            }
+          }
+
+        }
+
+      }
+
+      "display the page" in {
+
+        val session = Fixtures.individualHECSession(
+          loginData = Fixtures.individualLoginData(emailAddress = ggEmailId.some),
+          userAnswers = Fixtures.completeIndividualUserAnswers(),
+          isEmailRequested = true,
+          userEmailAnswers = Fixtures
+            .userEmailAnswers(
+              passcodeRequestResult = PasscodeRequestResult.PasscodeSent.some,
+              passcode = expiredPasscode.some,
+              passcodeVerificationResult = PasscodeVerificationResult.Expired.some
+            )
+            .some
+        )
+
+        inSequence {
+          mockAuthWithNoRetrievals()
+          mockGetSession(session)
+          mockJourneyServiceGetPrevious(
+            routes.VerificationPasscodeExpiredController.verificationPasscodeExpired(),
+            session
+          )(
+            mockPreviousCall
+          )
+        }
+        checkPageIsDisplayed(
+          performAction(),
+          messageFromMessageKey("verifyPasscodeExpired.title"),
+          { doc =>
+            doc.select("#back").attr("href") shouldBe mockPreviousCall.url
+
+            val htmlBody = doc.select(".govuk-body").html()
+
+            htmlBody should include regex messageFromMessageKey(
+              "verifyPasscodeExpired.p2",
+              routes.ResendEmailConfirmationController.resendEmail().url,
+              routes.StartController.start().url
+            )
+
+          }
+        )
+
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/VerifyEmailPasscodeControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/VerifyEmailPasscodeControllerSpec.scala
@@ -84,6 +84,25 @@ class VerifyEmailPasscodeControllerSpec
           }
           assertThrows[RuntimeException](await(performAction()))
         }
+
+        "session failed to get updated" in {
+
+          val session = Fixtures.individualHECSession(
+            loginData = Fixtures.individualLoginData(emailAddress = ggEmailId.some),
+            userAnswers = Fixtures.completeIndividualUserAnswers(),
+            isEmailRequested = true,
+            userEmailAnswers =
+              Fixtures.userEmailAnswers(passcodeRequestResult = PasscodeRequestResult.PasscodeSent.some).some
+          )
+
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(session)
+            mockStoreSession(session.copy(hasResentEmailConfirmation = false))(Left(Error("")))
+          }
+          assertThrows[RuntimeException](await(performAction()))
+
+        }
       }
 
       "display the page" when {
@@ -99,6 +118,7 @@ class VerifyEmailPasscodeControllerSpec
           inSequence {
             mockAuthWithNoRetrievals()
             mockGetSession(session)
+            mockStoreSession(session.copy(hasResentEmailConfirmation = false))(Right(()))
             mockJourneyServiceGetPrevious(routes.VerifyEmailPasscodeController.verifyEmailPasscode(), session)(
               mockPreviousCall
             )
@@ -147,6 +167,7 @@ class VerifyEmailPasscodeControllerSpec
           test(userEmailAnswers = Fixtures.userEmailAnswers().some, ggEmailId.some)
 
         }
+
         "User hasn't  previously entered the passcode and session has no ggEmail Id" in {
 
           test(userEmailAnswers = Fixtures.userEmailAnswers().some, None)

--- a/test/uk/gov/hmrc/hecapplicantfrontend/controllers/VerifyResentEmailPasscodeControllerSpec.scala
+++ b/test/uk/gov/hmrc/hecapplicantfrontend/controllers/VerifyResentEmailPasscodeControllerSpec.scala
@@ -88,6 +88,23 @@ class VerifyResentEmailPasscodeControllerSpec
           assertThrows[RuntimeException](await(performAction()))
         }
 
+        "session failed to updated" in {
+          val session = Fixtures.individualHECSession(
+            loginData = Fixtures.individualLoginData(emailAddress = ggEmailId.some),
+            userAnswers = Fixtures.completeIndividualUserAnswers(),
+            isEmailRequested = true,
+            userEmailAnswers =
+              Fixtures.userEmailAnswers(passcodeRequestResult = PasscodeRequestResult.PasscodeSent.some).some
+          )
+
+          inSequence {
+            mockAuthWithNoRetrievals()
+            mockGetSession(session)
+            mockStoreSession(session.copy(hasResentEmailConfirmation = true))(Left(Error("")))
+          }
+          assertThrows[RuntimeException](await(performAction()))
+        }
+
       }
 
       "display the page" when {
@@ -104,6 +121,7 @@ class VerifyResentEmailPasscodeControllerSpec
           inSequence {
             mockAuthWithNoRetrievals()
             mockGetSession(session)
+            mockStoreSession(session.copy(hasResentEmailConfirmation = true))(Right(()))
             mockJourneyServiceGetPrevious(
               routes.VerifyResentEmailPasscodeController.verifyResentEmailPasscode(),
               session


### PR DESCRIPTION
This Pr is for the page when email conformation code is expired
[page](https://hec-applicant-tax-check.herokuapp.com/v9/email-code-expired?email=a99@example.com)
I did a bug fix where , when we reach to resend  email confirmation page, it's back was always verify email passcode page, even if it's reached via verify resent email passcode page.
steps to repro:
1) click any email address on confirm email page.
2) on verify email passcode page, click on the link "request a new confirmation code".
3) resend email confirmation page will appear, click on resend button.
4)verify resend confirmation email passcode will appear, click on on the link "request a new confirmation code".
5) resend email confirmation page will appear, click on back link
6) It should take to verify resend email confirmation passcode  page , earlier it was taking to verify email confirmation passcode.