### PR TITLE
HEC-1821 upgrade hmrc-play-frontend to 3.4.0

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,7 +10,7 @@ object AppDependencies {
   val compile = Seq(
     "uk.gov.hmrc"                %% "bootstrap-frontend-play-28"    % bootStrapVersion,
     "uk.gov.hmrc.mongo"          %% "hmrc-mongo-play-28"            % hmrcMongoVersion,
-    "uk.gov.hmrc"                %% "play-frontend-hmrc"            % "1.31.0-play-28",
+    "uk.gov.hmrc"                %% "play-frontend-hmrc"            % "3.4.0-play-28",
     "uk.gov.hmrc"                %% "domain"                        % "6.2.0-play-28",
     "org.typelevel"              %% "cats-core"                     % "2.7.0",
     "ai.x"                       %% "play-json-extensions"          % "0.42.0",


### PR DESCRIPTION
Browser checks on journeys are fine and unit tests still pass after upgrade.