### PR TITLE
DDCYLS-2049

### DIFF
--- a/app/uk/gov/hmrc/hecapplicantfrontend/models/DateOfBirth.scala
+++ b/app/uk/gov/hmrc/hecapplicantfrontend/models/DateOfBirth.scala
@@ -16,13 +16,20 @@
 
 package uk.gov.hmrc.hecapplicantfrontend.models
 
-import play.api.libs.json.{Format, Json}
+import play.api.libs.functional.syntax.toInvariantFunctorOps
+import play.api.libs.json.Format
 
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 final case class DateOfBirth(value: LocalDate) extends AnyVal
 
 object DateOfBirth {
 
-  implicit val format: Format[DateOfBirth] = Json.valueFormat
+  private val dateFormatter = DateTimeFormatter.ISO_LOCAL_DATE
+
+  implicit val format: Format[DateOfBirth] =
+    implicitly[Format[String]]
+      .inmap(s => DateOfBirth(LocalDate.parse(s, dateFormatter)), d => dateFormatter.format(d.value))
+
 }


### PR DESCRIPTION
Using ISO_LOCAL_DATE for the Date Time Formatting. 
Odd because that is the default one that should be in use, but parsing the unparseable text in production locally using that format works fine:
```
import java.time.LocalDate
import java.time.DateTimeFormatter
val parsed = LocalDate.parse("1982-02-19", DateTimeFormatter.ISO_LOCAL_DATE)
```

resulted in: parsed: `parsed: java.time.LocalDate = 1982-02-19`

But using something like BASIC_ISO_DATE didn't work & resulted in the exception that we saw in production.